### PR TITLE
Add `#[inline]` attribute to `Allocation` destructor

### DIFF
--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -161,6 +161,7 @@ impl Allocation {
 }
 
 impl Drop for Allocation {
+    #[inline]
     fn drop(&mut self) {
         unsafe {
             __rust_deallocate(self.ptr.as_ptr(), self.len, self.align);


### PR DESCRIPTION
This matches the `#[inline]` annotation on `alloc::heap::deallocate`.