### PR TITLE
Add `Allocation::duplicate`

### DIFF
--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -9,7 +9,7 @@
 
 #![cfg_attr(feature = "clippy", allow(inline_always))]
 
-use core::{fmt, isize};
+use core::{fmt, intrinsics, isize};
 use core::ptr::Unique;
 use super::error::Error;
 use super::result::Result;
@@ -135,6 +135,23 @@ impl Allocation {
                     __rust_reallocate_inplace(self.as_mut_ptr(), self.len, new_len, self.align)
                 };
                 Ok(())
+            }
+        )
+    }
+
+    /// Creates a new memory allocation with the same length, alignment and contents as an
+    /// existing allocation.
+    pub fn duplicate(&self) -> Result<Allocation> {
+        Allocation::new(self.len, self.align).map(
+            |mut new_alloc| {
+                unsafe {
+                    intrinsics::copy_nonoverlapping(
+                        self.as_ptr(),
+                        new_alloc.as_mut_ptr(),
+                        self.len,
+                    );
+                }
+                new_alloc
             }
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 #![no_std]
 #![needs_allocator]
 #![feature(allocator)]
+#![feature(core_intrinsics)]
 #![feature(needs_allocator)]
 #![feature(unique)]
 #![cfg_attr(feature = "clippy", feature(plugin))]


### PR DESCRIPTION
This method offers a way to clone `Allocation`s without running the risk of panicking if memory allocation fails.